### PR TITLE
feat: add stellar fee bump and transaction XDR support

### DIFF
--- a/custom-models/stellar-transaction-request.ts
+++ b/custom-models/stellar-transaction-request.ts
@@ -84,9 +84,12 @@ export type StellarOperationSpec =
 
 // Main transaction request type
 export interface StellarTransactionRequest {
-  source_account: string;
   network: string;
-  operations: StellarOperationSpec[];
+  source_account?: string;
+  operations?: StellarOperationSpec[];
+  transaction_xdr?: string;
+  fee_bump?: boolean;
+  max_fee?: number;
   memo?: StellarMemoSpec;
   valid_until?: string;
 }

--- a/examples/stellar/sendFeeBumpTransaction.ts
+++ b/examples/stellar/sendFeeBumpTransaction.ts
@@ -1,0 +1,56 @@
+/**
+ * Stellar Send Fee Bump Transaction Example
+ *
+ * This example demonstrates how to use the OpenZeppelin Relayer SDK to send a fee bump
+ * transaction on Stellar. This is useful when you have a pre-signed transaction and need
+ * the relayer to pay the fees by wrapping it in a fee bump transaction.
+ *
+ * IMPORTANT: This is provided as a demonstration only. For production use:
+ * - Use proper error handling and transaction confirmation checks
+ * - Implement appropriate security measures for API keys and tokens
+ * - Consider rate limiting and monitoring for production applications
+ * - Test thoroughly on testnet before using on mainnet
+ * - Use https connection for production applications
+ *
+ * Usage:
+ *   ts-node sendFeeBumpTransaction.ts
+ */
+import { Configuration, RelayersApi, StellarTransactionRequest } from '../../src';
+
+// example dev config
+const config = new Configuration({
+  basePath: 'http://localhost:8080',
+  accessToken: '', // replace with your actual api key
+});
+
+const relayersApi = new RelayersApi(config);
+
+// replace with your actual ids
+const relayer_id = 'stellar-testnet';
+
+// Replace with your signed transaction XDR that needs fee bumping
+const UNSIGNED_XDR = '';
+
+async function main() {
+  try {
+    const transaction: StellarTransactionRequest = {
+      network: 'testnet',
+      transaction_xdr: UNSIGNED_XDR,
+      fee_bump: true,
+      max_fee: 1000000, // 0.1 XLM
+    };
+
+    console.log('Sending fee bump transaction...');
+    console.log('Original signed XDR:', UNSIGNED_XDR);
+    console.log('Max fee:', transaction.max_fee, 'stroops (', transaction.max_fee! / 10000000, 'XLM)');
+
+    const response = await relayersApi.sendTransaction(relayer_id, transaction);
+
+    console.log('Fee bump transaction submitted successfully:');
+    console.log(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    console.error('Error sending fee bump transaction:', error);
+  }
+}
+
+main();

--- a/examples/stellar/sendTransactionXdr.ts
+++ b/examples/stellar/sendTransactionXdr.ts
@@ -1,0 +1,52 @@
+/**
+ * Stellar Send Transaction with XDR Example
+ *
+ * This example demonstrates how to use the OpenZeppelin Relayer SDK to send a pre-built
+ * transaction using XDR (External Data Representation) on Stellar.
+ *
+ * IMPORTANT: This is provided as a demonstration only. For production use:
+ * - Use proper error handling and transaction confirmation checks
+ * - Implement appropriate security measures for API keys and tokens
+ * - Consider rate limiting and monitoring for production applications
+ * - Test thoroughly on testnet before using on mainnet
+ * - Use https connection for production applications
+ *
+ * Usage:
+ *   ts-node sendTransactionXdr.ts
+ */
+import { Configuration, RelayersApi, StellarTransactionRequest } from '../../src';
+
+// example dev config
+const config = new Configuration({
+  basePath: 'http://localhost:8080',
+  accessToken: '', // replace with your actual api key
+});
+
+const relayersApi = new RelayersApi(config);
+
+// replace with your actual ids
+const relayer_id = 'stellar-testnet';
+
+// Replace with your unsigned transaction XDR
+const UNSIGNED_XDR = '';
+
+async function main() {
+  try {
+    const transaction: StellarTransactionRequest = {
+      network: 'testnet',
+      transaction_xdr: UNSIGNED_XDR,
+    };
+
+    console.log('Sending transaction with XDR...');
+    console.log('XDR:', UNSIGNED_XDR);
+
+    const response = await relayersApi.sendTransaction(relayer_id, transaction);
+
+    console.log('Transaction submitted successfully:');
+    console.log(JSON.stringify(response.data, null, 2));
+  } catch (error) {
+    console.error('Error sending transaction:', error);
+  }
+}
+
+main();

--- a/openapi.json
+++ b/openapi.json
@@ -3677,8 +3677,17 @@
       },
       "StellarTransactionRequest": {
         "type": "object",
-        "required": ["source_account", "network", "operations"],
+        "required": ["network"],
         "properties": {
+          "fee_bump": {
+            "type": ["boolean", "null"],
+            "description": "Explicitly request fee-bump wrapper\nOnly valid when transaction_xdr contains a signed transaction"
+          },
+          "max_fee": {
+            "type": ["integer", "null"],
+            "format": "int64",
+            "description": "Maximum fee in stroops (defaults to 0.1 XLM = 1,000,000 stroops)"
+          },
           "memo": {
             "oneOf": [
               {
@@ -3693,13 +3702,17 @@
             "type": "string"
           },
           "operations": {
-            "type": "array",
+            "type": ["array", "null"],
             "items": {
               "$ref": "#/components/schemas/OperationSpec"
             }
           },
           "source_account": {
-            "type": "string"
+            "type": ["string", "null"]
+          },
+          "transaction_xdr": {
+            "type": ["string", "null"],
+            "description": "Pre-built transaction XDR (base64 encoded, signed or unsigned)\nMutually exclusive with operations field"
           },
           "valid_until": {
             "type": ["string", "null"]

--- a/src/models/stellar-transaction-request.ts
+++ b/src/models/stellar-transaction-request.ts
@@ -84,9 +84,12 @@ export type StellarOperationSpec =
 
 // Main transaction request type
 export interface StellarTransactionRequest {
-  source_account: string;
   network: string;
-  operations: StellarOperationSpec[];
+  source_account?: string;
+  operations?: StellarOperationSpec[];
+  transaction_xdr?: string;
+  fee_bump?: boolean;
+  max_fee?: number;
   memo?: StellarMemoSpec;
   valid_until?: string;
 }


### PR DESCRIPTION
# Summary

- Updated StellarTransactionRequest to include optional fields: fee_bump, max_fee, and transaction_xdr.
- Modified the required properties to only include network.
- Added new examples for sending fee bump transactions and transactions using XDR.
## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add the changeset file. (run `npx changeset add`)
