### PR TITLE
fix(package): remove postinstall husky script command

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "url": "https://github.com/OpenZeppelin/openzeppelin-relayer-sdk.git"
   },
   "scripts": {
-    "postinstall": "husky",
     "commit": "cz",
     "clean:client": "rimraf ./src",
     "clean:dist": "rimraf ./dist",


### PR DESCRIPTION
**Issue**: postinstall script causes installation failures for package consumers

**Problem**: The package has `"postinstall": "husky"` which runs development setup tools when users install the package as a dependency. This causes installation failures in consumer projects.

**Solution**: Remove the postinstall script and keep only the prepare script.

**Why**:
- `postinstall` runs for all users installing the package
- `prepare` only runs during package development
- Development tools like `husky` should not run in consumer environments