### PR TITLE
fix: correct package entry points

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "generate:client": "pnpm clean:client && pnpm openapi-generator-cli generate -i ./openapi.json -g typescript-axios -o ./src  -c ./config.json",
     "generate:docs": "pnpm openapi-generator-cli generate -i ./openapi.json -g markdown -o docs",
     "post:generate:client": "node scripts/post-generate.js",
-    "build:client": "pnpm clean:dist && tsc",
+    "build:client": "pnpm clean:dist && tsc -p src/tsconfig.json",
     "generate": "pnpm generate:client && pnpm post:generate:client && pnpm build:client",
     "prepare": "husky",
     "pre-commit": "lint-staged",

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,7 +4,7 @@
     "target": "ES6",
     "module": "commonjs",
     "noImplicitAny": true,
-    "outDir": "dist",
+    "outDir": "../dist",
     "rootDir": ".",
     "moduleResolution": "node",
     "typeRoots": [


### PR DESCRIPTION
**Problem**: Users had to import from `@openzeppelin/relayer-sdk/dist/src` instead of the expected `@openzeppelin/relayer-sdk` due to misaligned build output and `package.json` entry points.

**Solution**: 
•  Fixed TypeScript compilation to output directly to `dist/` instead of `dist/src/`
•  Updated build script to use correct `tsconfig`

**Result**: Enables standard imports:
```typescript
import { Configuration, RelayersApi } from '@openzeppelin/relayer-sdk';
```

Files changed:
•  `src/tsconfig.json`: Adjusted `outDir` path
•  `package.json`: Updated `build:client` script