### PR TITLE
chore: pin pnpm to 11.1.0 + 7-day minimumReleaseAge

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,11 +85,25 @@
   "dependencies": {
     "axios": "^1.7.7"
   },
+  "packageManager": "pnpm@11.1.0",
   "engines": {
     "node": ">=22.14.0",
     "npm": "use pnpm",
-    "pnpm": ">=9",
+    "pnpm": ">=11",
     "yarn": "use pnpm"
+  },
+  "pnpm": {
+    "minimumReleaseAge": 10080,
+    "minimumReleaseAgeExclude": [
+      "@openzeppelin/*"
+    ],
+    "onlyBuiltDependencies": [
+      "@nestjs/core",
+      "@openapitools/openapi-generator-cli",
+      "@stellar/stellar-sdk",
+      "keccak",
+      "nx"
+    ]
   },
   "config": {
     "commitizen": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,6 @@
+allowBuilds:
+  '@nestjs/core': true
+  '@openapitools/openapi-generator-cli': true
+  '@stellar/stellar-sdk': true
+  keccak: true
+  nx: true


### PR DESCRIPTION
# Summary

Mirrors changes from other OZ repos

- Pins packageManager: pnpm@11.1.0 (latest)
- Adds engines.pnpm: ">=11"
- Adds pnpm.minimumReleaseAge: 10080 (= 7 days, in minutes)
- Adds pnpm.minimumReleaseAgeExclude: ["@openzeppelin/*"]

## Testing Process

## Checklist

- [ ] Add a reference to related issues in the PR description.
- [ ] Add unit tests if applicable.
- [ ] Add the changeset file. (run `npx changeset add`)
